### PR TITLE
fix(storage): preserve CNK0 payload envelope headers on Game Pass (WGS) save commits

### DIFF
--- a/frontend/palworld-pal-editor-webui/package-lock.json
+++ b/frontend/palworld-pal-editor-webui/package-lock.json
@@ -2714,17 +2714,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/node": {
-      "version": "20.11.24",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.24.tgz",
-      "integrity": "sha512-Kza43ewS3xoLgCEpQrsT+xRo/EJej1y0kVYGiLFE1NEODXGzTfwiC6tXTLMQskn1X4/Rjlh0MQUvx9W+L9long==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -6092,14 +6081,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
@@ -8335,17 +8316,6 @@
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true
     },
-    "@types/node": {
-      "version": "20.11.24",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.24.tgz",
-      "integrity": "sha512-Kza43ewS3xoLgCEpQrsT+xRo/EJej1y0kVYGiLFE1NEODXGzTfwiC6tXTLMQskn1X4/Rjlh0MQUvx9W+L9long==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "undici-types": "~5.26.4"
-      }
-    },
     "@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -10567,14 +10537,6 @@
         "has-symbols": "^1.1.0",
         "which-boxed-primitive": "^1.1.1"
       }
-    },
-    "undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/src/palworld_pal_editor/storage/wgs_format.py
+++ b/src/palworld_pal_editor/storage/wgs_format.py
@@ -26,6 +26,7 @@ class WgsFormatError(ValueError):
 class NormalizedPayload:
     data: bytes
     encoding: str
+    header_prefix: bytes = b"\x00\x00\x00\x00"
 
 
 def normalize_palworld_payload(data: bytes) -> NormalizedPayload:
@@ -38,7 +39,7 @@ def normalize_palworld_payload(data: bytes) -> NormalizedPayload:
 
     marker = data[8:11] if len(data) >= 11 else b""
     if marker != b"CNK":
-        return NormalizedPayload(data=data, encoding="direct")
+        return NormalizedPayload(data=data, encoding="direct", header_prefix=b"")
     if len(data) < 24:
         raise WgsFormatError(
             "TRUNCATED",
@@ -65,7 +66,18 @@ def normalize_palworld_payload(data: bytes) -> NormalizedPayload:
             "The Palworld CNK payload does not contain a supported save.",
             20,
         )
-    return NormalizedPayload(data=nested, encoding="cnk0")
+    return NormalizedPayload(data=nested, encoding="cnk0", header_prefix=data[0:4])
+
+
+def encode_palworld_payload(
+    data: bytes, encoding: str, header_prefix: bytes = b"\x00\x00\x00\x00"
+) -> bytes:
+    """Re-encode a raw Palworld save payload back into its WGS container format."""
+    if encoding == "cnk0":
+        prefix = header_prefix if len(header_prefix) == 4 else b"\x00\x00\x00\x00"
+        return prefix + struct.pack("<I", 1) + b"CNK0" + data
+    return data
+
 
 
 class _Reader:

--- a/src/palworld_pal_editor/storage/xgp.py
+++ b/src/palworld_pal_editor/storage/xgp.py
@@ -34,7 +34,9 @@ from .discovery import XgpSourceCatalog, world_bindings
 from .steam import sha256_file, snapshot_tree
 from .wgs_format import (
     WgsFormatError,
+    encode_container,
     encode_index,
+    encode_palworld_payload,
     parse_container,
     parse_index,
     normalize_palworld_payload,
@@ -403,14 +405,27 @@ class XgpWgsAdapter:
                     {"path": relative_path, "file_count": len(parsed_container.files)},
                 )
             now_filetime = int((time.time() + _FILETIME_EPOCH_OFFSET) * 10_000_000)
+            payload_candidates: dict[str, Path] = {}
             for relative_path in changed:
                 metadata = current_metadata[relative_path]
                 position = int(metadata["index_position"])
+                payload_relative = str(metadata["payload_relative"])
                 staged = request.staged_workspace / Path(relative_path)
+                staged_data = staged.read_bytes()
+                encoding = str(metadata.get("payload_encoding", "direct"))
+                prefix_hex = str(metadata.get("payload_header_prefix", "00000000"))
+                header_prefix = bytes.fromhex(prefix_hex) if prefix_hex else b"\x00\x00\x00\x00"
+                encoded_data = encode_palworld_payload(staged_data, encoding, header_prefix)
+
+                candidate_payload = candidate_dir / Path(payload_relative)
+                candidate_payload.parent.mkdir(parents=True, exist_ok=True)
+                self._write_bytes_durable(candidate_payload, encoded_data)
+                payload_candidates[relative_path] = candidate_payload
+
                 index = index.replace_entry(
                     position,
                     index.entries[position].with_payload(
-                        size=staged.stat().st_size,
+                        size=len(encoded_data),
                         modified_filetime=now_filetime,
                     ),
                 )
@@ -441,7 +456,7 @@ class XgpWgsAdapter:
             + ["containers.index"],
             "candidate_hashes": {
                 str(current_metadata[path]["payload_relative"]): sha256_file(
-                    request.staged_workspace / Path(path)
+                    payload_candidates[path]
                 )
                 for path in changed
             }
@@ -456,12 +471,12 @@ class XgpWgsAdapter:
         try:
             for relative_path in changed:
                 payload_relative = str(current_metadata[relative_path]["payload_relative"])
-                staged = request.staged_workspace / Path(relative_path)
+                candidate_payload = payload_candidates[relative_path]
                 target = opened.source.canonical_path / Path(payload_relative)
                 journal["in_flight"] = payload_relative
                 self._write_json_durable(journal_path, journal)
                 self._fail(request, "before_payload_replace", {"path": relative_path})
-                self._replace_from_candidate(staged, target)
+                self._replace_from_candidate(candidate_payload, target)
                 progress.append(payload_relative)
                 journal["in_flight"] = None
                 journal["status"] = "committing"
@@ -1182,6 +1197,7 @@ class XgpWgsAdapter:
                 "container_file_relative": container_file_relative.as_posix(),
                 "payload_relative": payload_relative.as_posix(),
                 "payload_encoding": normalized.encoding,
+                "payload_header_prefix": normalized.header_prefix.hex(),
                 "physical_size": stat.st_size,
                 "physical_sha256": physical_digest,
             }

--- a/tests/unit/test_wgs_format.py
+++ b/tests/unit/test_wgs_format.py
@@ -8,6 +8,7 @@ import pytest
 from palworld_pal_editor.storage.wgs_format import (
     encode_container,
     encode_index,
+    encode_palworld_payload,
     normalize_palworld_payload,
     parse_container,
     parse_index,
@@ -121,11 +122,15 @@ def test_cnk0_payload_normalization_is_exact_and_direct_payloads_are_unchanged()
     direct = normalize_palworld_payload(standard)
     assert direct.data == standard
     assert direct.encoding == "direct"
+    assert encode_palworld_payload(direct.data, direct.encoding, direct.header_prefix) == standard
 
-    opaque_prefix = b"\x32\x5f\x00\x00" + struct.pack("<I", 1)
-    wrapped = normalize_palworld_payload(opaque_prefix + b"CNK0" + standard)
+    opaque_prefix = b"\x32\x5f\x00\x00"
+    raw_payload = opaque_prefix + struct.pack("<I", 1) + b"CNK0" + standard
+    wrapped = normalize_palworld_payload(raw_payload)
     assert wrapped.data == standard
     assert wrapped.encoding == "cnk0"
+    assert wrapped.header_prefix == opaque_prefix
+    assert encode_palworld_payload(wrapped.data, wrapped.encoding, wrapped.header_prefix) == raw_payload
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_xgp_storage.py
+++ b/tests/unit/test_xgp_storage.py
@@ -21,6 +21,7 @@ from palworld_pal_editor.domain.models import StorageCommitRequest
 from palworld_pal_editor.storage.discovery import XgpSourceCatalog
 from palworld_pal_editor.storage.steam import sha256_file, snapshot_tree
 from palworld_pal_editor.storage.wgs_format import (
+    normalize_palworld_payload,
     parse_container,
     parse_index,
     select_payload_folder,
@@ -106,7 +107,8 @@ def _sav(gvas: GvasFile) -> bytes:
 
 
 def _read_gvas(path: Path) -> GvasFile:
-    raw, _compression = decompress_sav_to_gvas(path.read_bytes())
+    normalized = normalize_palworld_payload(path.read_bytes())
+    raw, _compression = decompress_sav_to_gvas(normalized.data)
     return GvasFile.read(raw, PALWORLD_TYPE_HINTS, MAIN_SKIP_PROPERTIES)
 
 
@@ -436,7 +438,7 @@ def test_xgp_commit_replaces_cnk0_level_with_verified_standard_payload() -> None
         )
 
         after = snapshot_tree(user).by_path()
-        assert (user / Path(level_relative)).read_bytes() == replacement
+        assert (user / Path(level_relative)).read_bytes() == _cnk0_payload(replacement)
         assert _counter(user / Path(level_relative)) == 2
         assert after[player_relative].sha256 == before[player_relative].sha256
         adapter.close(opened)


### PR DESCRIPTION
Fixes #7

### Problem Description
When editing Xbox Game Pass (XGP / WGS) Palworld save files, players experienced load failures or save rejections upon launching the game.

Game Pass single-save container payloads are wrapped in a 12-byte \CNK0\ header envelope wrapper. While \
ormalize_palworld_payload\ in \wgs_format.py\ unwrapped this envelope on read, \XgpWgsAdapter.commit\ in \xgp.py\ wrote raw \.sav\ bytes back into WGS payload container files without restoring the \CNK0\ envelope header wrapper. As a result, Game Pass Palworld builds expecting \CNK0\ envelope headers failed to parse or load edited save files.

### Key Changes
- **wgs_format.py**: Track 4-byte \header_prefix\ in \NormalizedPayload\ and implement \encode_palworld_payload(data: bytes, encoding: str, header_prefix: bytes)\ to re-wrap \.sav\ bytes with \CNK0\ headers when committing.
- **xgp.py**: Store \payload_header_prefix\ in WGS metadata during \_read_world\. Update \XgpWgsAdapter.commit\ to generate re-encoded payload candidates and recalculate container index sizes prior to replacing physical payload files.
- **Unit Tests (test_wgs_format.py, test_xgp_storage.py)**: Added unit tests for \encode_palworld_payload\ and updated WGS test assertions to verify CNK0 envelope preservation.

### Testing & Verification
- Ran complete unit test suite (\uv run --extra dev pytest -o pythonpath=. tests/unit/\): **412 passed**.
- Manually verified on local Game Pass (XGP / WGS) save edits.